### PR TITLE
Make reference to license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+test-more-php
+=============
+
+This project is licensed under the same terms as the Perl language.
+See [Perl Licensing](http://dev.perl.org/licenses/).


### PR DESCRIPTION
According to the Google code project page, test-more-php is under the Perl license. I've added a README to help document that fact before Google code shuts down forever.